### PR TITLE
Bugfix for RMSDPlusForce where periodic box wrapping used to create d…

### DIFF
--- a/openmmapi/include/RMSDPlusForce.h
+++ b/openmmapi/include/RMSDPlusForce.h
@@ -37,6 +37,7 @@
 #include "openmm/Vec3.h"
 #include <vector>
 #include "internal/windowsExportRMSDPlusForce.h"
+#include <iostream>
 
 using namespace OpenMM;
 namespace RMSDPlusForcePlugin {
@@ -97,9 +98,7 @@ public:
     
     void updateParametersInContext(OpenMM::Context& context);
     
-    bool usesPeriodicBoundaryConditions() const {
-        return false;
-    }
+    bool usesPeriodicBoundaryConditions() const;
     
 protected:
     OpenMM::ForceImpl* createImpl() const;

--- a/openmmapi/src/RMSDPlusForce.cpp
+++ b/openmmapi/src/RMSDPlusForce.cpp
@@ -63,11 +63,11 @@ void RMSDPlusForce::getRMSDPlusAlignParameters(int index, int& particle) const {
 	particle = alignParticles[index];
 }
 
-void RMSDPlusForce::getRMSDPlusRMSDParameters(int index, int& particle) const{
+void RMSDPlusForce::getRMSDPlusRMSDParameters(int index, int& particle) const {
 	particle = rmsdParticles[index];
 }
 
-void RMSDPlusForce::getRMSDPlusReferencePosition(int index, Vec3& position) const{
+void RMSDPlusForce::getRMSDPlusReferencePosition(int index, Vec3& position) const {
 	position = referencePositions[index];
 }
 
@@ -77,4 +77,8 @@ ForceImpl* RMSDPlusForce::createImpl() const {
 
 void RMSDPlusForce::updateParametersInContext(Context& context) {
     dynamic_cast<RMSDPlusForceImpl&>(getImplInContext(context)).updateParametersInContext(getContextImpl(context));
+}
+
+bool RMSDPlusForce::usesPeriodicBoundaryConditions() const {
+    return true;
 }

--- a/platforms/common/src/CommonRMSDPlusKernels.h
+++ b/platforms/common/src/CommonRMSDPlusKernels.h
@@ -35,6 +35,7 @@
 #include "RMSDPlusKernels.h"
 #include "openmm/common/ComputeContext.h"
 #include "openmm/common/ComputeArray.h"
+#include <builtin_types.h>
 
 namespace RMSDPlusForcePlugin {
 
@@ -95,6 +96,8 @@ private:
 	int blockSize;
 	double sumNormRef;
 	ComputeArray referencePos, alignParticles, rmsdParticles, buffer;
+	bool use_periodic;
+	double4 periodicBoxVecX, periodicBoxVecY, periodicBoxVecZ, periodicBoxSize, invPeriodicBoxSize;
 	ComputeKernel kernel1, kernel2, kernel3;
 };
 

--- a/platforms/common/src/kernels/RMSDPlusForce.cc
+++ b/platforms/common/src/kernels/RMSDPlusForce.cc
@@ -26,15 +26,41 @@ DEVICE real reduceValue(real value, LOCAL_ARG volatile real* temp) {
  * Perform the first step of computing the RMSD.  This is executed as a single work group.
  */
 KERNEL void computeRMSDPart1(int numAlignParticles, 
+        //bool use_periodic,
+        //real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+        //real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
         GLOBAL const real4* RESTRICT posq, GLOBAL const real4* RESTRICT referencePos,
-        GLOBAL const int* RESTRICT alignParticles, GLOBAL real* buffer) {
+        GLOBAL const int* RESTRICT alignParticles, GLOBAL real* buffer
+        ) {
     LOCAL volatile real temp[THREAD_BLOCK_SIZE];
 
     // Compute the center of the align particle positions.
 
     real3 center = make_real3(0);
+    real3 pos = make_real3(0);
+    //real scale1;
+    //real scale2;
+    //real scale3;
     for (int i = LOCAL_ID; i < numAlignParticles; i += LOCAL_SIZE)
-        center += trimTo3(posq[alignParticles[i]]);
+        pos = trimTo3(posq[alignParticles[i]]);
+        /*
+        if (use_periodic == true) {
+            //APPLY_PERIODIC_TO_POS(pos);
+            
+            real scale3 = floor(pos.z*invPeriodicBoxSize.z);
+            pos.x -= scale3*periodicBoxVecZ.x;
+            pos.y -= scale3*periodicBoxVecZ.y;
+            pos.z -= scale3*periodicBoxVecZ.z;
+            real scale2 = floor(pos.y*invPeriodicBoxSize.y);
+            pos.x -= scale2*periodicBoxVecY.x;
+            pos.y -= scale2*periodicBoxVecY.y;
+            real scale1 = floor(pos.x*invPeriodicBoxSize.x);
+            pos.x -= scale1*periodicBoxVecX.x;
+            
+        }
+        */
+        center += pos;
+        //center += trimTo3(posq[alignParticles[i]]);
     center.x = reduceValue(center.x, temp)/numAlignParticles;
     center.y = reduceValue(center.y, temp)/numAlignParticles;
     center.z = reduceValue(center.z, temp)/numAlignParticles;
@@ -45,8 +71,39 @@ KERNEL void computeRMSDPart1(int numAlignParticles,
     real sum = 0;
     for (int i = LOCAL_ID; i < numAlignParticles; i += LOCAL_SIZE) {
         int index = alignParticles[i];
-        real3 pos = trimTo3(posq[index]) - center;
+        real3 temppos = trimTo3(posq[index]);
         real3 refPos = trimTo3(referencePos[index]);
+        /*
+        if (use_periodic == true) {
+            APPLY_PERIODIC_TO_POS(temppos);
+            
+            scale3 = floor(temppos.z*invPeriodicBoxSize.z);
+            temppos.x -= scale3*periodicBoxVecZ.x;
+            temppos.y -= scale3*periodicBoxVecZ.y;
+            temppos.z -= scale3*periodicBoxVecZ.z;
+            scale2 = floor(temppos.y*invPeriodicBoxSize.y);
+            temppos.x -= scale2*periodicBoxVecY.x;
+            temppos.y -= scale2*periodicBoxVecY.y;
+            scale1 = floor(temppos.x*invPeriodicBoxSize.x);
+            temppos.x -= scale1*periodicBoxVecX.x;
+            
+            APPLY_PERIODIC_TO_POS(refPos);
+            
+            scale3 = floor(refPos.z*invPeriodicBoxSize.z);
+            refPos.x -= scale3*periodicBoxVecZ.x;
+            refPos.y -= scale3*periodicBoxVecZ.y;
+            refPos.z -= scale3*periodicBoxVecZ.z;
+            scale2 = floor(refPos.y*invPeriodicBoxSize.y);
+            refPos.x -= scale2*periodicBoxVecY.x;
+            refPos.y -= scale2*periodicBoxVecY.y;
+            scale1 = floor(refPos.x*invPeriodicBoxSize.x);
+            refPos.x -= scale1*periodicBoxVecX.x;
+            
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(temppos, center);
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(refPos, center);
+        }
+        */
+        pos = temppos - center;
         R[0][0] += pos.x*refPos.x;
         R[0][1] += pos.x*refPos.y;
         R[0][2] += pos.x*refPos.z;
@@ -79,23 +136,44 @@ KERNEL void computeRMSDPart1(int numAlignParticles,
 /**
  * Compute the RMSD of the rmsdParticles
  */
-KERNEL void computeRMSDPart2(int numRMSDParticles, 
+KERNEL void computeRMSDPart2(int numRMSDParticles, bool use_periodic,
+        real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ,
         GLOBAL const real4* RESTRICT posq, GLOBAL const real4* RESTRICT referencePos,
         GLOBAL const int* RESTRICT rmsdParticles, GLOBAL real* buffer) {
     LOCAL volatile real temp[THREAD_BLOCK_SIZE];
     
     real3 center = make_real3(buffer[10], buffer[11], buffer[12]);
     real sum = 0;
+    real3 pos = make_real3(0);
+    real3 delta = make_real3(0);
     for (int i = LOCAL_ID; i < numRMSDParticles; i += LOCAL_SIZE) {
         int index = rmsdParticles[i];
-        real3 pos = trimTo3(posq[index]) - center;
+        //real3 pos = trimTo3(posq[index]) - center;
+        real3 temppos = trimTo3(posq[index]);
         real3 refPos = trimTo3(referencePos[index]);
+        /*
+        if (use_periodic == true) {
+            APPLY_PERIODIC_TO_POS(temppos);
+            APPLY_PERIODIC_TO_POS(refPos);
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(temppos, center);
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(refPos, center);
+        }
+        */
+        pos = temppos - center;
         real3 rotatedRef = make_real3(buffer[0]*refPos.x + buffer[3]*refPos.y + buffer[6]*refPos.z,
                                       buffer[1]*refPos.x + buffer[4]*refPos.y + buffer[7]*refPos.z,
                                       buffer[2]*refPos.x + buffer[5]*refPos.y + buffer[8]*refPos.z);
-        sum += (pos.x - rotatedRef.x)*(pos.x - rotatedRef.x);
-        sum += (pos.y - rotatedRef.y)*(pos.y - rotatedRef.y);
-        sum += (pos.z - rotatedRef.z)*(pos.z - rotatedRef.z);
+        // TODO: try APPLY_PERIODIC_TO_DELTA here?
+        delta.x = pos.x - rotatedRef.x;
+        delta.y = pos.y - rotatedRef.y;
+        delta.z = pos.z - rotatedRef.z;
+        if (use_periodic == true) {
+            APPLY_PERIODIC_TO_DELTA(delta);
+        }
+        sum += delta.x*delta.x;
+        sum += delta.y*delta.y;
+        sum += delta.z*delta.z;
     }
     sum = reduceValue(sum, temp);
     
@@ -109,19 +187,39 @@ KERNEL void computeRMSDPart2(int numRMSDParticles,
 /**
  * Apply forces based on the RMSD.
  */
-KERNEL void computeRMSDForces(int numRMSDParticles, int paddedNumAtoms, 
+KERNEL void computeRMSDForces(int numRMSDParticles, bool use_periodic,
+        real4 periodicBoxSize, real4 invPeriodicBoxSize, 
+        real4 periodicBoxVecX, real4 periodicBoxVecY, real4 periodicBoxVecZ, int paddedNumAtoms,
         GLOBAL const real4* RESTRICT posq, GLOBAL const real4* RESTRICT referencePos,
-        GLOBAL const int* RESTRICT rmsdParticles, GLOBAL const real* buffer, GLOBAL mm_long* RESTRICT forceBuffers) {
+        GLOBAL const int* RESTRICT rmsdParticles, GLOBAL const real* buffer, GLOBAL mm_long* RESTRICT forceBuffers
+        ) {
     real3 center = make_real3(buffer[10], buffer[11], buffer[12]);
+    real3 delta = make_real3(0);
     real scale = 1 / (real) (buffer[9]*numRMSDParticles);
     for (int i = GLOBAL_ID; i < numRMSDParticles; i += GLOBAL_SIZE) {
         int index = rmsdParticles[i];
-        real3 pos = trimTo3(posq[index]) - center;
+        real3 temppos = trimTo3(posq[index]);
         real3 refPos = trimTo3(referencePos[index]);
+        /*
+        if (use_periodic == true) {
+            APPLY_PERIODIC_TO_POS(temppos);
+            APPLY_PERIODIC_TO_POS(refPos);
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(temppos, center);
+            //APPLY_PERIODIC_TO_POS_WITH_CENTER(refPos, center);
+        }
+        */
+        real3 pos = temppos - center;
         real3 rotatedRef = make_real3(buffer[0]*refPos.x + buffer[3]*refPos.y + buffer[6]*refPos.z,
                                       buffer[1]*refPos.x + buffer[4]*refPos.y + buffer[7]*refPos.z,
                                       buffer[2]*refPos.x + buffer[5]*refPos.y + buffer[8]*refPos.z);
-        real3 force = (rotatedRef-pos)*scale;
+        delta.x = rotatedRef.x - pos.x;
+        delta.y = rotatedRef.y - pos.y;
+        delta.z = rotatedRef.z - pos.z;
+        if (use_periodic == true) {
+            APPLY_PERIODIC_TO_DELTA(delta);
+        }
+        //real3 force = (rotatedRef-pos)*scale;
+        real3 force = delta*scale;
         forceBuffers[index] += realToFixedPoint(force.x);
         forceBuffers[index+paddedNumAtoms] += realToFixedPoint(force.y);
         forceBuffers[index+2*paddedNumAtoms] += realToFixedPoint(force.z);


### PR DESCRIPTION
…iscontinuous jumps in the RMSD value. Now, the closest periodic image is always used between the simulation structure and reference structure. Additionally, a small bugfix was implemented when align particle positions are very close, but rmsd particles are not.